### PR TITLE
Set the theme-color meta tag

### DIFF
--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -34,4 +34,3 @@
 <meta name='msapplication-config' content='{{ icon_url }}/browserconfig.xml'>
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="{{ icon_url }}/ms-icon-144x144.png">
-<meta name="theme-color" content="#ffffff">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,4 +17,3 @@
   {%- include js-selector.html -%}
   <!-- fix - support missing in jekyll-seo-tag -->
   <meta property="og:image:alt" content="Marina Gornostaeva's profile picture" />
-


### PR DESCRIPTION
Safari uses the background color for pages to change the color of the window chrome on macOS and the color of the safe area on iOS (which is otherwise set to white, which is a bit jarring when contrasted with dark backgrounds) - for some reason, it doesn't always manage to detect the color properly so this meta tag forces it to use the specified value.

It does add a slight maintenance burden if you want to toggle different styles or you change theme or something in the future, but I think it's worth it.

I tried getting ruby/jekyll to work on two different machines to test this out, but because ruby is such a friendly and straightforward ecosystem that I really love I ran into some issues so this is currently untested (mainly in the sense that I'm not sure this is the right include, I'm pretty sure the meta tag will have the desired effect 😅)